### PR TITLE
minimum spec guide for infra pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@
 ## 설치 가이드
 1. virtvnc 서비스를 제공할 컨테이너 설정을 위해 yamls/virtvnc.yaml을 필요에 맞게 수정합니다. Service의 spec.ports[0].port 부분의 값이 cluster에서 노출되는 port입니다.
 2. ```make install``` 을 수행하여 설치를 진행합니다.
+3. virt-api와 virt-controller deployments에 대한 replicas를 1로 하고 싶은 경우 아래의 명령어를 수행합니다.\
+  ```kubectl patch deployment virt-api --patch '{"spec":{"replicas":1}}' -n kubevirt```\
+  ```kubectl patch deployment virt-controller --patch '{"spec":{"replicas":1}}' -n kubevirt```
 
 ## 삭제 가이드
 1. ```make uninstall```을 수행하여 삭제를 진행합니다.

--- a/manifest/yamls/kubevirt-operator.yaml
+++ b/manifest/yamls/kubevirt-operator.yaml
@@ -594,7 +594,7 @@ metadata:
   name: virt-operator
   namespace: kubevirt
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       kubevirt.io: virt-operator

--- a/manifest/yamls/virtvnc.yaml
+++ b/manifest/yamls/virtvnc.yaml
@@ -84,6 +84,13 @@ spec:
       containers:
       - name: virtvnc
         image: tmaxcloudck/virtvnc:v0.1
+		resources:
+		  requests:
+		    memory: "200Mi"
+			cpu: "200m"
+		  limits:
+		    memory: "1000Mi"
+			cpu: "1000m"
         livenessProbe:
           httpGet:
             port: 8001


### PR DESCRIPTION
1. virt-operator deployment의 replicas를 2에서 1로 수정
2. 그 외의 deployment인 virt-controller, virt-api는 현재 버전에서는 customize를 할 수 없어 replicas를 patch를 이용하여 할 수 있도록 README.md에 가이드 추가
3. virtvnc deployment에 대한 resources requests/limits 명시