### PR TITLE
fix indent from tab to space in virtvnc.yaml

### DIFF
--- a/manifest/yamls/virtvnc.yaml
+++ b/manifest/yamls/virtvnc.yaml
@@ -84,13 +84,13 @@ spec:
       containers:
       - name: virtvnc
         image: tmaxcloudck/virtvnc:v0.1
-		resources:
-		  requests:
-		    memory: "200Mi"
-			cpu: "200m"
-		  limits:
-		    memory: "1000Mi"
-			cpu: "1000m"
+        resources:
+          requests:
+            memory: "200Mi"
+            cpu: "200m"
+          limits:
+            memory: "1000Mi"
+            cpu: "1000m"
         livenessProbe:
           httpGet:
             port: 8001


### PR DESCRIPTION
1. yaml의 indent가 탭으로 되어 있는 부분을 space로 수정